### PR TITLE
Bump dotnet version to dotnet 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod
     && dpkg -i packages-microsoft-prod.deb
 
 # Fix JRE Install https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
-mkdir -p /usr/share/man/man1
+RUN mkdir -p /usr/share/man/man1
 
 # Install the .NET Core Runtime for SonarScanner.
 # The warning message "delaying package configuration, since apt-utils is not installed" is probably not an actual error, just a warning.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 LABEL "com.github.actions.name"="sonarscan-dotnet"
-LABEL "com.github.actions.description"="Sonarscanner for .NET Core with pull request decoration support."
+LABEL "com.github.actions.description"="Sonarscanner for .NET 5 with pull request decoration support."
 LABEL "com.github.actions.icon"="check-square"
 LABEL "com.github.actions.color"="blue"
 
@@ -21,7 +21,7 @@ RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod
 # Fix JRE Install https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN mkdir -p /usr/share/man/man1
 
-# Install the .NET Core Runtime for SonarScanner.
+# Install the .NET 5 Runtime for SonarScanner.
 # The warning message "delaying package configuration, since apt-utils is not installed" is probably not an actual error, just a warning.
 # We don't need apt-utils, we won't install it. The image seems to work even with the warning.
 RUN apt-get update -y \
@@ -32,7 +32,7 @@ RUN apt-get update -y \
 # Install Java Runtime for SonarScanner
 RUN apt-get install --no-install-recommends -y openjdk-$JRE_VERSION-jre
 
-# Install SonarScanner .NET Core global tool
+# Install SonarScanner .NET global tool
 RUN dotnet tool install dotnet-sonarscanner --tool-path . --version $SONAR_SCANNER_DOTNET_TOOL_VERSION
 
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.403
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 LABEL "com.github.actions.name"="sonarscan-dotnet"
 LABEL "com.github.actions.description"="Sonarscanner for .NET Core with pull request decoration support."
@@ -11,7 +11,7 @@ LABEL "maintainer"="Highbyte"
 
 # Version numbers of used software
 ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=4.10.0 \
-    DOTNETCORE_RUNTIME_VERSION=3.1 \
+    DOTNETCORE_RUNTIME_VERSION=5.0 \
     JRE_VERSION=11
 
 # Add Microsoft Debian apt-get feed 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=4.10.0 \
 RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb
 
+# Fix JRE Install https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
+mkdir -p /usr/share/man/man1
+
 # Install the .NET Core Runtime for SonarScanner.
 # The warning message "delaying package configuration, since apt-utils is not installed" is probably not an actual error, just a warning.
 # We don't need apt-utils, we won't install it. The image seems to work even with the warning.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL "homepage"="https://github.com/highbyte"
 LABEL "maintainer"="Highbyte"
 
 # Version numbers of used software
-ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=4.10.0 \
+ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=5.0.3 \
     DOTNETCORE_RUNTIME_VERSION=5.0 \
     JRE_VERSION=11
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Also includes test results.
 ```
 
 ## Use with self-hosted SonarQube
-_Note: This has not yet been verified if it works_
+
 ``` yaml
     - name: SonarScanner for .NET Core with pull request decoration support
       uses: highbyte/sonarscan-dotnet@1.0.2


### PR DESCRIPTION
* Bumped used docker image to .net 5
* Bumped used sonar scanner version to 5.X (required for .net 5)
* Bumped installed .net runtime version to 5
* Fixed an issue with JRE installation
* Updated readme because the action was tested with a selfhosted sonarQube