### PR TITLE
Bump Java SDK to v17 and SonarScanner .NET tool to 5.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ LABEL "homepage"="https://github.com/highbyte"
 LABEL "maintainer"="Highbyte"
 
 # Version numbers of used software
-ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=5.8.0 \
+ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=5.13.1 \
     DOTNETCORE_RUNTIME_VERSION=5.0 \
-    JRE_VERSION=11
+    JRE_VERSION=17
 
 # Add Microsoft Debian apt-get feed 
 RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The current version supports .NET 7
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.2
+      uses: highbyte/sonarscan-dotnet@v2.2.3
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -35,7 +35,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.2
+      uses: highbyte/sonarscan-dotnet@v2.2.3
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -58,7 +58,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.2
+      uses: highbyte/sonarscan-dotnet@v2.2.3
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -82,7 +82,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.2
+      uses: highbyte/sonarscan-dotnet@v2.2.3
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -102,7 +102,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.2
+      uses: highbyte/sonarscan-dotnet@v2.2.3
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -124,7 +124,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.2
+      uses: highbyte/sonarscan-dotnet@v2.2.3
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey


### PR DESCRIPTION
The previous Java SDK version (v11) will soon no longer be supported by SonarScan.