### PR TITLE
Feature/use sonar token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The current version supports .NET 7
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5
+      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -35,7 +35,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5
+      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -58,7 +58,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5
+      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -82,7 +82,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5
+      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -102,7 +102,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5
+      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -124,7 +124,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5
+      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The current version supports .NET 7
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -35,7 +35,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -58,7 +58,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -82,7 +82,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -102,7 +102,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -124,7 +124,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The current version supports .NET 7
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.4
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -35,7 +35,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.4
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -58,7 +58,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.4
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -82,7 +82,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.4
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -102,7 +102,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.4
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -124,7 +124,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 7 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.2.4
+      uses: highbyte/sonarscan-dotnet@v2.2.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.2.5-beta"
+  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.2.5"
 
 branding:
   icon: 'check-square'

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.2.4"
+  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.2.5-beta"
 
 branding:
   icon: 'check-square'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,7 +82,7 @@ echo "INPUT_SONARHOSTNAME: $INPUT_SONARHOSTNAME"
 #-----------------------------------
 # Build Sonarscanner begin command
 #-----------------------------------
-sonar_begin_cmd="/dotnet-sonarscanner begin /k:\"${INPUT_SONARPROJECTKEY}\" /n:\"${INPUT_SONARPROJECTNAME}\" /d:sonar.login=\"${SONAR_TOKEN}\" /d:sonar.host.url=\"${INPUT_SONARHOSTNAME}\""
+sonar_begin_cmd="/dotnet-sonarscanner begin /k:\"${INPUT_SONARPROJECTKEY}\" /n:\"${INPUT_SONARPROJECTNAME}\" /d:sonar.token=\"${SONAR_TOKEN}\" /d:sonar.host.url=\"${INPUT_SONARHOSTNAME}\""
 if [ -n "$INPUT_SONARORGANIZATION" ]; then
     sonar_begin_cmd="$sonar_begin_cmd /o:\"${INPUT_SONARORGANIZATION}\""
 fi
@@ -109,7 +109,7 @@ fi
 #-----------------------------------
 # Build Sonarscanner end command
 #-----------------------------------
-sonar_end_cmd="/dotnet-sonarscanner end /d:sonar.login=\"${SONAR_TOKEN}\""
+sonar_end_cmd="/dotnet-sonarscanner end /d:sonar.token=\"${SONAR_TOKEN}\""
 
 #-----------------------------------
 # Build pre build command


### PR DESCRIPTION
Fix sonar scanner warning about using ```sonar.login``` parameter, about to be deprecated. Replaced with ```sonar.token```.