### PR TITLE
Feature/2.1 backport from 2.2

### DIFF
--- a/BUILD_RELEASE.md
+++ b/BUILD_RELEASE.md
@@ -1,0 +1,20 @@
+# Building new release
+
+_TODO: This workflow should be improved_
+
+- Clone the GitHub repository locally
+- Create new Git branch (feature/name-of-feature)
+- Decide what the new full version number should be. If it's a pre-release, use -beta suffix in version number.
+- Build and push docker image
+  - Authenticate to ghcr.io using [these instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)
+  - `docker build -t ghcr.io/highbyte/sonarscan-dotnet:v1.0.0 .` where v1.0.0 is the full version number.
+  - `docker push ghcr.io/highbyte/sonarscan-dotnet:v1.0.0` where v1.0.0 is the full version number.
+- Update `action.yml` to point to the new docker tag version,
+- Update `README.md` instructions to the new version,
+- Push new branch from local repository to GitHub.
+- Create [GitHub release](https://github.com/highbyte/sonarscan-dotnet/releases) with the full version number.
+  - If pre-rerelease (beta), check the Pre-release box.
+  - Check the box to release it to the GitHub Marketplace.
+  - Publish the release
+- Verify the release from a workflow in another repo using the new version
+- If the version is not a pre-release, create a GitHub PR to merge the new branch to master

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "homepage"="https://github.com/highbyte"
 LABEL "maintainer"="Highbyte"
 
 # Version numbers of used software
-ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=5.13.1 \
+ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=5.14 \
     DOTNETCORE_RUNTIME_VERSION=5.0 \
     NODE_VERSION=20 \
     JRE_VERSION=17

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL "com.github.actions.description"="Sonarscanner for .NET 6 with pull reques
 LABEL "com.github.actions.icon"="check-square"
 LABEL "com.github.actions.color"="blue"
 
+LABEL "org.opencontainers.image.source"="https://github.com/highbyte/sonarscan-dotnet"
+
 LABEL "repository"="https://github.com/highbyte/sonarscan-dotnet"
 LABEL "homepage"="https://github.com/highbyte"
 LABEL "maintainer"="Highbyte"
@@ -12,6 +14,7 @@ LABEL "maintainer"="Highbyte"
 # Version numbers of used software
 ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=5.13.1 \
     DOTNETCORE_RUNTIME_VERSION=5.0 \
+    NODE_VERSION=20 \
     JRE_VERSION=17
 
 # Add Microsoft Debian apt-get feed 
@@ -28,6 +31,14 @@ RUN apt-get update -y \
     && apt-get install --no-install-recommends -y apt-transport-https \
     && apt-get update -y \
     && apt-get install --no-install-recommends -y aspnetcore-runtime-$DOTNETCORE_RUNTIME_VERSION
+    
+# Install NodeJS
+RUN apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update -y \
+    && apt-get install nodejs -y
 
 # Install Java Runtime for SonarScanner
 RUN apt-get install --no-install-recommends -y openjdk-$JRE_VERSION-jre
@@ -40,6 +51,6 @@ RUN apt-get -q -y autoremove \
     && apt-get -q clean -y \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The current version supports .NET 6
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.1.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -34,7 +34,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.1.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -57,7 +57,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.1.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -81,7 +81,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.1.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -101,7 +101,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.1.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -123,7 +123,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
+      uses: highbyte/sonarscan-dotnet@v2.1.5
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The current version supports .NET 6
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.4
+      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -34,7 +34,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.4
+      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -57,7 +57,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.4
+      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -81,7 +81,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.4
+      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -101,7 +101,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.4
+      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -123,7 +123,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 6 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.1.4
+      uses: highbyte/sonarscan-dotnet@v2.1.5-beta
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.1.5-beta"
+  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.1.5"
 
 branding:
   icon: 'check-square'

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.1.5-beta"
 
 branding:
   icon: 'check-square'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,7 +82,7 @@ echo "INPUT_SONARHOSTNAME: $INPUT_SONARHOSTNAME"
 #-----------------------------------
 # Build Sonarscanner begin command
 #-----------------------------------
-sonar_begin_cmd="/dotnet-sonarscanner begin /k:\"${INPUT_SONARPROJECTKEY}\" /n:\"${INPUT_SONARPROJECTNAME}\" /d:sonar.login=\"${SONAR_TOKEN}\" /d:sonar.host.url=\"${INPUT_SONARHOSTNAME}\""
+sonar_begin_cmd="/dotnet-sonarscanner begin /k:\"${INPUT_SONARPROJECTKEY}\" /n:\"${INPUT_SONARPROJECTNAME}\" /d:sonar.token=\"${SONAR_TOKEN}\" /d:sonar.host.url=\"${INPUT_SONARHOSTNAME}\""
 if [ -n "$INPUT_SONARORGANIZATION" ]; then
     sonar_begin_cmd="$sonar_begin_cmd /o:\"${INPUT_SONARORGANIZATION}\""
 fi
@@ -109,7 +109,7 @@ fi
 #-----------------------------------
 # Build Sonarscanner end command
 #-----------------------------------
-sonar_end_cmd="/dotnet-sonarscanner end /d:sonar.login=\"${SONAR_TOKEN}\""
+sonar_end_cmd="/dotnet-sonarscanner end /d:sonar.token=\"${SONAR_TOKEN}\""
 
 #-----------------------------------
 # Build pre build command


### PR DESCRIPTION

Backport of improvements from the current version v2.2.6 (.NET 7) to the the 2.1 release branch (.NET 6):
- Uses a pre-built Docker image for reduced execution time. Pulls the Docker image for the Action rather then building it every time.
- Bump the Nodejs version from v.19 to v.20 (LTS). Also changes how it's installed.
- Remove warning about SonarScanner property ```sonar.login``` that will be deprecated. Changed to ```sonar.token```.

Also bumps the SonarScanner version to 5.14.