### PR TITLE
feat: dotnet 8.0.1 support + sonarscan 6.0 update + version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0.100
+FROM mcr.microsoft.com/dotnet/sdk:8.0.101
 
 LABEL "com.github.actions.name"="sonarscan-dotnet"
 LABEL "com.github.actions.description"="Sonarscanner for .NET 8 with pull request decoration support."
@@ -12,8 +12,8 @@ LABEL "homepage"="https://github.com/highbyte"
 LABEL "maintainer"="Highbyte"
 
 # Version numbers of used software
-ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=5.14 \
-    DOTNETCORE_RUNTIME_VERSION=6.0 \
+ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=6.0 \
+    DOTNETCORE_RUNTIME_VERSION=8.0 \
     NODE_VERSION=20 \
     JRE_VERSION=17
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current version supports .NET 8
 
 ``` yaml
     - name: SonarScanner for .NET 8 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.3.0
+      uses: highbyte/sonarscan-dotnet@v2.3.1
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -36,7 +36,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 8 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.3.0
+      uses: highbyte/sonarscan-dotnet@v2.3.1
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -59,7 +59,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 8 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.3.0
+      uses: highbyte/sonarscan-dotnet@v2.3.1
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -83,7 +83,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 8 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.3.0
+      uses: highbyte/sonarscan-dotnet@v2.3.1
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -103,7 +103,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 8 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.3.0
+      uses: highbyte/sonarscan-dotnet@v2.3.1
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -125,7 +125,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 8 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.3.0
+      uses: highbyte/sonarscan-dotnet@v2.3.1
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.3.0"
+  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.3.1"
 
 branding:
   icon: 'check-square'


### PR DESCRIPTION
FIX #29

I tested also the dotnet runtime update from 6.0 to 8.0 seems to work.
The Dockerfile build without problems