### PR TITLE
Bump .NET 9 SDK to v9.0.201 and other dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.100
+FROM mcr.microsoft.com/dotnet/sdk:9.0.201
 
 LABEL "com.github.actions.name"="sonarscan-dotnet"
 LABEL "com.github.actions.description"="SonarScanner for .NET 9 with pull request decoration support."
@@ -12,13 +12,13 @@ LABEL "homepage"="https://github.com/highbyte"
 LABEL "maintainer"="Highbyte"
 
 # Version numbers of used software
-ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=9.0.1 \
-    DOTNETCORE_RUNTIME_VERSION=8.0 \
+ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=9.2.1 \
+    DOTNETCORE_RUNTIME_VERSION=9.0 \
     NODE_VERSION=22 \
     JRE_VERSION=17
 
 # Add Microsoft Debian apt-get feed 
-RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+RUN wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb
 
 # Fix JRE Install https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SonarScanner for .NET for use in Github Actions, with automatic pull request det
 
 ``` yaml
     - name: SonarScanner for .NET 9 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.4.1
+      uses: highbyte/sonarscan-dotnet@v2.4.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -41,7 +41,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 9 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.4.1
+      uses: highbyte/sonarscan-dotnet@v2.4.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -64,7 +64,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 9 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.4.1
+      uses: highbyte/sonarscan-dotnet@v2.4.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -88,7 +88,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 9 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.4.1
+      uses: highbyte/sonarscan-dotnet@v2.4.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -108,7 +108,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 9 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.4.1
+      uses: highbyte/sonarscan-dotnet@v2.4.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -130,7 +130,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 9 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.4.1
+      uses: highbyte/sonarscan-dotnet@v2.4.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.4.1"
+  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.4.2-beta"
 
 branding:
   icon: 'check-square'

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.4.2-beta"
+  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.4.2"
 
 branding:
   icon: 'check-square'


### PR DESCRIPTION
# .NET SDK
Docker image changed from .NET 9.0.100 to .NET 9.0.201 SDK.

# SonarScanner
SonarScanner for .NET version changed to v9.2.1.
ASP.NET Runtime changed to v9.0.

