### PR TITLE
Update JRE version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag highbyte/sonarscan-dotnet:$(date +%s)
+      run: docker build . --file Dockerfile --tag dssldavidmorgan/sonarscan-dotnet:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL "maintainer"="Highbyte"
 ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=11.0.0 \
     DOTNETCORE_RUNTIME_VERSION=9.0 \
     NODE_VERSION=22 \
-    JRE_VERSION=17
+    JRE_VERSION=21
 
 # Add Microsoft Debian apt-get feed 
 RUN wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ LABEL "com.github.actions.description"="SonarScanner for .NET 10 with pull reque
 LABEL "com.github.actions.icon"="check-square"
 LABEL "com.github.actions.color"="blue"
 
-LABEL "org.opencontainers.image.source"="https://github.com/highbyte/sonarscan-dotnet"
+LABEL "org.opencontainers.image.source"="https://github.com/dssldavidmorgan/sonarscan-dotnet"
 
-LABEL "repository"="https://github.com/highbyte/sonarscan-dotnet"
-LABEL "homepage"="https://github.com/highbyte"
-LABEL "maintainer"="Highbyte"
+LABEL "repository"="https://github.com/dssldavidmorgan/sonarscan-dotnet"
+LABEL "homepage"="https://github.com/dssldavidmorgan"
+LABEL "maintainer"="dssldavidmorgan"
 
 # Version numbers of used software
 ENV SONAR_SCANNER_DOTNET_TOOL_VERSION=11.0.0 \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SonarScanner for .NET for use in Github Actions, with automatic pull request det
 
 ``` yaml
     - name: SonarScanner for .NET 10 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.5.0
+      uses: dssldavidmorgan/sonarscan-dotnet@v1.0.0-alpha.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -42,7 +42,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 10 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.5.0
+      uses: dssldavidmorgan/sonarscan-dotnet@v1.0.0-alpha.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -65,7 +65,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 10 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.5.0
+      uses: dssldavidmorgan/sonarscan-dotnet@v1.0.0-alpha.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -89,7 +89,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 10 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.5.0
+      uses: dssldavidmorgan/sonarscan-dotnet@v1.0.0-alpha.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -109,7 +109,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 10 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.5.0
+      uses: dssldavidmorgan/sonarscan-dotnet@v1.0.0-alpha.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey
@@ -131,7 +131,7 @@ Also includes test results.
 
 ``` yaml
     - name: SonarScanner for .NET 10 with pull request decoration support
-      uses: highbyte/sonarscan-dotnet@v2.5.0
+      uses: dssldavidmorgan/sonarscan-dotnet@v1.0.0-alpha.2
       with:
         # The key of the SonarQube project
         sonarProjectKey: your_projectkey

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/highbyte/sonarscan-dotnet:v2.5.0"
+  image: "docker://ghcr.io/dssldavidmorgan/sonarscan-dotnet:v1.0.0-alpha.2"
 
 branding:
   icon: 'check-square'


### PR DESCRIPTION
Update JRE from version 17 to 21. 17 is no longer supported by SonarCloud.

```
13:25:01.453  ERROR: 

The version of Java (17) used to run this analysis is deprecated, and SonarQube Cloud no longer supports it. Please upgrade to Java 21 or later.
You can find more information here: https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/scanners/scanner-environment/general-requirements

13:25:01.782  The scanner engine did not complete successfully
```